### PR TITLE
【feature】はじめての体験記録のCRUD機能を実装

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,0 +1,19 @@
+class RecordsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  def index
+  end
+end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,19 +1,44 @@
 class RecordsController < ApplicationController
+  def index
+    @records = current_user.records.order(date: :desc)
+  end
+
   def new
+    @record = Record.new
   end
 
   def create
+    @record = current_user.records.build(record_params)
+    if @record.save
+      redirect_to records_path, notice: "記録が作成されました。"
+    else
+      flash.now[:alert] = "記録に失敗しました。"
+      render :new
+    end
   end
 
   def edit
+    @record = current_user.records.find(params[:id])
   end
 
   def update
+    @record = current_user.records.find(params[:id])
+    if @record.update(record_params)
+      redirect_to records_path, notice: "記録が更新されました。"
+    else
+      render :edit
+    end
   end
 
   def destroy
+    @record = current_user.records.find(params[:id])
+    @record.destroy!
+    redirect_to records_path, notice: "記録が削除されました。"
   end
 
-  def index
+  private
+
+  def record_params
+    params.require(:record).permit(:title, :memo, :date)
   end
 end

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -1,0 +1,2 @@
+module RecordsHelper
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,0 +1,3 @@
+class Record < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,3 +1,6 @@
 class Record < ApplicationRecord
   belongs_to :user
+
+  validates :title, presence: true
+  validates :date, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :records, dependent: :destroy
+
   validates :email, presence: true, uniqueness: true
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:password] }

--- a/app/views/records/_form.html.erb
+++ b/app/views/records/_form.html.erb
@@ -1,0 +1,30 @@
+<% if @record.errors.any? %>
+  <div>
+    <ul>
+      <% @record.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with model: @record, local: true do |f| %>
+  <div>
+    <%= f.label :title, 'タイトル' %><br>
+    <%= f.text_field :title %>
+  </div>
+
+  <div>
+    <%= f.label :memo, 'メモ' %><br>
+    <%= f.text_area :memo %>
+  </div>
+
+  <div>
+    <%= f.label :date, '日付' %><br>
+    <%= f.date_field :date %>
+  </div>
+
+  <div>
+    <%= f.submit '記録する' %>
+  </div>
+<% end %>

--- a/app/views/records/create.html.erb
+++ b/app/views/records/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Records#create</h1>
+<p>Find me in app/views/records/create.html.erb</p>

--- a/app/views/records/destroy.html.erb
+++ b/app/views/records/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Records#destroy</h1>
+<p>Find me in app/views/records/destroy.html.erb</p>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Records#edit</h1>
+<p>Find me in app/views/records/edit.html.erb</p>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -1,2 +1,3 @@
-<h1>Records#edit</h1>
-<p>Find me in app/views/records/edit.html.erb</p>
+<h1>はじめての思い出を手直し</h1>
+
+<%= render 'form' %>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Records#index</h1>
+<p>Find me in app/views/records/index.html.erb</p>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -1,2 +1,13 @@
-<h1>Records#index</h1>
-<p>Find me in app/views/records/index.html.erb</p>
+<h1>わたしのはじめてリスト</h1>
+
+<% @records.each do |record| %>
+  <div>
+    <h2><%= record.title %></h2>
+    <p><%= record.memo %></p>
+    <p><%= record.date.strftime('%Y-%m-%d') %></p>
+    <%= link_to '編集', edit_record_path(record) %> |
+    <%= link_to '削除', record_path(record), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
+  </div>
+<% end %>
+
+<%= link_to '新たにはじめてを刻む', new_record_path %>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Records#new</h1>
+<p>Find me in app/views/records/new.html.erb</p>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,2 +1,3 @@
-<h1>Records#new</h1>
-<p>Find me in app/views/records/new.html.erb</p>
+<h1>はじめてを刻む</h1>
+
+<%= render 'form' %>

--- a/app/views/records/update.html.erb
+++ b/app/views/records/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Records#update</h1>
+<p>Find me in app/views/records/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  get "records/new"
-  get "records/create"
-  get "records/edit"
-  get "records/update"
-  get "records/destroy"
-  get "records/index"
   # ルートパス
   root "static_pages#home"
 
@@ -16,6 +10,8 @@ Rails.application.routes.draw do
   get "login", to: "user_sessions#new", as: "login"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy", as: "logout"
+
+  resources :records, only: [ :index, :new, :create, :edit, :update, :destroy ]
 
   # アプリケーションのヘルスチェック
   get "up", to: "rails/health#show", as: :rails_health_check

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  get "records/new"
+  get "records/create"
+  get "records/edit"
+  get "records/update"
+  get "records/destroy"
+  get "records/index"
   # ルートパス
   root "static_pages#home"
 

--- a/db/migrate/20240924173207_create_records.rb
+++ b/db/migrate/20240924173207_create_records.rb
@@ -1,0 +1,12 @@
+class CreateRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :records do |t|
+      t.string :title
+      t.text :memo
+      t.date :date
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_24_145424) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_24_173207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "records", force: :cascade do |t|
+    t.string "title"
+    t.text "memo"
+    t.date "date"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_records_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -22,4 +32,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_24_145424) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
+  add_foreign_key "records", "users"
 end

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -4,7 +4,7 @@ class RecordsControllerTest < ActionDispatch::IntegrationTest
   # setup メソッドで事前にログインを行う
   setup do
     @user = users(:one) # fixtureのユーザーを使用する
-    post login_path, params: { email: @user.email, password: 'password' } # 適切なログイン情報を入力
+    post login_path, params: { email: @user.email, password: "password" } # 適切なログイン情報を入力
   end
 
   test "should get index" do

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class RecordsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get records_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get records_create_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get records_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get records_update_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get records_destroy_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get records_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -1,33 +1,42 @@
 require "test_helper"
 
 class RecordsControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
-    get records_new_url
-    assert_response :success
-  end
-
-  test "should get create" do
-    get records_create_url
-    assert_response :success
-  end
-
-  test "should get edit" do
-    get records_edit_url
-    assert_response :success
-  end
-
-  test "should get update" do
-    get records_update_url
-    assert_response :success
-  end
-
-  test "should get destroy" do
-    get records_destroy_url
-    assert_response :success
+  # setup メソッドで事前にログインを行う
+  setup do
+    @user = users(:one) # fixtureのユーザーを使用する
+    post login_path, params: { email: @user.email, password: 'password' } # 適切なログイン情報を入力
   end
 
   test "should get index" do
-    get records_index_url
+    get records_path
     assert_response :success
+  end
+
+  test "should get new" do
+    get new_record_path
+    assert_response :success
+  end
+
+  test "should create record" do
+    post records_path, params: { record: { title: "Test", memo: "Test memo", date: "2024-09-24" } }
+    assert_response :redirect
+  end
+
+  test "should get edit" do
+    record = records(:one) # 必要に応じてfixtureを作成
+    get edit_record_path(record)
+    assert_response :success
+  end
+
+  test "should update record" do
+    record = records(:one) # 必要に応じてfixtureを作成
+    patch record_path(record), params: { record: { title: "Updated title" } }
+    assert_response :redirect
+  end
+
+  test "should destroy record" do
+    record = records(:one) # 必要に応じてfixtureを作成
+    delete record_path(record)
+    assert_response :redirect
   end
 end

--- a/test/fixtures/records.yml
+++ b/test/fixtures/records.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  memo: MyText
+  date: 2024-09-25
+  user: one
+
+two:
+  title: MyString
+  memo: MyText
+  date: 2024-09-25
+  user: two

--- a/test/models/record_test.rb
+++ b/test/models/record_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要

このプルリクエストでは、ユーザーが「初めての体験」を記録・管理できるCRUD機能を実装しました。
この機能により、ユーザーは新しい体験を記録し、編集、削除、そして一覧で確認することができます。

### 変更内容

1. **Records CRUD機能の実装**:
   - `Record`モデルを作成し、`title`, `memo`, `date`, `user_id`カラムを追加。
   - `RecordsController`に `index`, `new`, `create`, `edit`, `update`, `destroy` アクションを追加。
   - ログインしたユーザーが自分の記録のみを管理できるように、関連するルートを定義。
   
2. **ビューの追加・修正**:
   - `app/views/records/index.html.erb`: 「はじめてリスト」ページを作成。ユーザーの体験をリスト形式で表示。
   - `app/views/records/new.html.erb`: 新しい体験を記録するフォームを実装。
   - `app/views/records/edit.html.erb`: 体験記録を編集するためのフォームを実装。
   - `app/views/records/_form.html.erb`: `new` と `edit` で共通のフォームを部分テンプレートとして実装。

3. **ルーティングの追加**:
   - `config/routes.rb` に `records` リソースのルートを追加し、CRUD機能に対応。

4. **バリデーションの追加**:
   - `Record`モデルにおいて、`title` と `date` のバリデーションを追加し、空での保存を防止。

5. **テストの追加・修正**:
   - `RecordsController`のCRUD機能に対するテストを追加し、正常な動作を確認。
   - ログイン状態のユーザーのみが体験記録を操作できるよう、テストでログイン処理を実装。

### 動作確認

- ユーザーは、自分の「初めての体験」を記録・編集・削除・一覧表示できることを確認しました。
- ユーザーがログインしていない場合、適切にリダイレクトされることを確認しました。
