### PR TITLE
【feature】「みんなのはじめて」リスト表示機能の実装

### DIFF
--- a/app/controllers/public_records_controller.rb
+++ b/app/controllers/public_records_controller.rb
@@ -1,4 +1,6 @@
 class PublicRecordsController < ApplicationController
+  skip_before_action :require_login, only: [ :index ]
+
   def index
     @public_records = Record.includes(:user).order(date: :desc)
   end

--- a/app/controllers/public_records_controller.rb
+++ b/app/controllers/public_records_controller.rb
@@ -1,4 +1,5 @@
 class PublicRecordsController < ApplicationController
   def index
+    @public_records = Record.includes(:user).order(date: :desc)
   end
 end

--- a/app/controllers/public_records_controller.rb
+++ b/app/controllers/public_records_controller.rb
@@ -1,0 +1,4 @@
+class PublicRecordsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
   end
 end

--- a/app/helpers/public_records_helper.rb
+++ b/app/helpers/public_records_helper.rb
@@ -1,0 +1,2 @@
+module PublicRecordsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:password] }
+
+  validates :name, presence: true
 end

--- a/app/views/public_records/index.html.erb
+++ b/app/views/public_records/index.html.erb
@@ -1,0 +1,2 @@
+<h1>PublicRecords#index</h1>
+<p>Find me in app/views/public_records/index.html.erb</p>

--- a/app/views/public_records/index.html.erb
+++ b/app/views/public_records/index.html.erb
@@ -1,2 +1,9 @@
-<h1>PublicRecords#index</h1>
-<p>Find me in app/views/public_records/index.html.erb</p>
+<h1>みんなのはじめて</h1>
+
+<% @public_records.each do |record| %>
+  <div>
+    <h2><%= record.title %></h2>
+    <p><%= record.date %></p>
+    <p>投稿者: <%= record.user.name %></p>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,17 +12,22 @@
 
 <%= form_with model: @user, local: true do |f| %>
   <div>
-    <%= f.label :email %><br>
+    <%= f.label :name, '名前' %><br>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :email, 'メールアドレス' %><br>
     <%= f.text_field :email %>
   </div>
 
   <div>
-    <%= f.label :password %><br>
+    <%= f.label :password, 'パスワード' %><br>
     <%= f.password_field :password %>
   </div>
 
   <div>
-    <%= f.label :password_confirmation %><br>
+    <%= f.label :password_confirmation, 'パスワード確認' %><br>
     <%= f.password_field :password_confirmation %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "public_records/index"
   # ルートパス
   root "static_pages#home"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get "public_records/index"
   # ルートパス
   root "static_pages#home"
 
@@ -13,6 +12,8 @@ Rails.application.routes.draw do
   delete "logout", to: "user_sessions#destroy", as: "logout"
 
   resources :records, only: [ :index, :new, :create, :edit, :update, :destroy ]
+
+  resources :public_records, only: [ :index ]
 
   # アプリケーションのヘルスチェック
   get "up", to: "rails/health#show", as: :rails_health_check

--- a/db/migrate/20240925150618_add_name_to_users.rb
+++ b/db/migrate/20240925150618_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_24_173207) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_25_150618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_24_173207) do
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/controllers/public_records_controller_test.rb
+++ b/test/controllers/public_records_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class PublicRecordsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get public_records_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/public_records_controller_test.rb
+++ b/test/controllers/public_records_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PublicRecordsControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get public_records_index_url
+    get public_records_path
     assert_response :success
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -7,7 +7,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create user" do
-    post users_path, params: { user: { email: "test@example.com", password: "password", password_confirmation: "password" } }
+    post users_path, params: { user: { name: "Test User", email: "test@example.com", password: "password", password_confirmation: "password" } }
     assert_response :redirect  # 正常に作成されたらリダイレクト
     follow_redirect!
     assert_response :success  # リダイレクト後のページが正常に表示されるか確認


### PR DESCRIPTION
### 概要

このプルリクエストでは、全ユーザーの「はじめての体験」を一覧表示するページ「みんなのはじめて」を実装しました。
この機能により、他のユーザーが記録した「はじめての体験」を閲覧でき、SNS風に共有する体験を提供します。

### 変更内容

- `PublicRecordsController`を追加し、全ユーザーの記録を取得し表示できるようにしました。
- `index` アクションでは、全ユーザーの `Record` モデルから `title`, `date`, `user_name` を取得し、リスト形式で表示します。
- ログインしていないユーザーでもアクセス可能にするため、`skip_before_action :require_login` を `PublicRecordsController` に追加しました。
- `public_records/index.html.erb` で、各記録に投稿者の名前が表示されるようにしました。

### 実装内容

1. **PublicRecordsController** の作成:
   - `index` アクションを実装し、全ユーザーの記録を取得・表示できるようにしました。
   - `skip_before_action :require_login, only: [:index]` を追加し、ログインしていないユーザーも閲覧可能にしました。

2. **ルーティングの追加**:
   - `public_records#index` のルートを設定しました。

3. **ビューの作成**:
   - `app/views/public_records/index.html.erb` において、全ユーザーの「はじめての体験」をリスト形式で表示しました。
   - 各記録に対して、タイトル、体験の日付、投稿者の名前を表示。

4. **テストの追加**:
   - `PublicRecordsControllerTest` に `index` アクションのテストを追加し、正常に動作することを確認しました。
  
### 関連Issue:
- Issue #5 
