### PR TITLE
【feature】Twitter共有機能の実装および投稿表示のパーシャル化

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,8 @@ module ApplicationHelper
       }
     }
   end
+
+  def tweet_text(record)
+    message = "生まれてはじめて「#{record.title}」 \n#ForTheFirstTime\n"
+  end
 end

--- a/app/views/public_records/index.html.erb
+++ b/app/views/public_records/index.html.erb
@@ -3,14 +3,7 @@
     <h1 class="my-10 text-center text-2xl font-bold">みんなのはじめて</h1>
 
     <% @public_records.each do |record| %>
-      <div class="card bg-cyan-50 w-full border mx-auto">
-        <div class="card-body">
-          <p><%= record.user.name %></p>
-          <h2 class="card-title"><%= record.title %></h2>
-          <p><%= record.memo %></p>
-          <p><%= record.date.strftime('%Y-%m-%d') %></p>
-        </div>
-      </div>
+      <%= render 'shared/record_card', record: record %>
     <% end %>
   </div>
 </div>

--- a/app/views/public_records/index.html.erb
+++ b/app/views/public_records/index.html.erb
@@ -1,6 +1,6 @@
-<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+<div class="flex min-h-full flex-col justify-center px-10 py-10 lg:px-8">
   <div class="mx-auto w-full">
-    <h1 class="my-10 text-center text-2xl font-bold">みんなのはじめて</h1>
+    <h1 class="my-16 text-center text-2xl font-bold">みんなのはじめて</h1>
 
     <% @public_records.each do |record| %>
       <%= render 'shared/record_card', record: record %>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -5,17 +5,7 @@
     <%= link_to '新たにはじめてを刻む', new_record_path, class: 'btn btn-primary mx-auto my-10' %>
 
     <% @records.each do |record| %>
-      <div class="card bg-cyan-50 w-full border mx-auto">
-        <div class="card-body">
-          <h2 class="card-title"><%= record.title %></h2>
-          <p><%= record.memo %></p>
-          <p><%= record.date.strftime('%Y-%m-%d') %></p>
-          <div class="card-actions justify-end">
-            <%= link_to '編集', edit_record_path(record), class: 'btn btn-info btn-outline btn-sm' %>
-            <%= link_to '削除', record_path(record), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-error btn-outline btn-sm' %>
-          </div>
-        </div>
-      </div>
+      <%= render 'shared/record_card', record: record %>
     <% end %>
   </div>
 </div>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -1,8 +1,8 @@
-<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+<div class="flex min-h-full flex-col justify-center px-10 py-10 lg:px-8">
   <div class="mx-auto w-full">
-    <h1 class="my-10 text-center text-2xl font-bold">わたしのはじめて</h1>
+    <h1 class="my-16 text-center text-2xl font-bold">わたしのはじめて</h1>
 
-    <%= link_to '新たにはじめてを刻む', new_record_path, class: 'btn btn-primary mx-auto my-10' %>
+    <%= link_to '新たにはじめてを刻む', new_record_path, class: 'btn btn-primary mx-auto mb-5' %>
 
     <% @records.each do |record| %>
       <%= render 'shared/record_card', record: record %>

--- a/app/views/shared/_record_card.html.erb
+++ b/app/views/shared/_record_card.html.erb
@@ -9,17 +9,17 @@
 
     <p><%= record.date.strftime('%Y-%m-%d') %></p>
 
-    <% if logged_in? && current_user == record.user %> <!-- ユーザーが投稿の所有者の場合にのみ表示 -->
-      <div class="card-actions justify-end">
+    <div class="card-actions justify-end">
+      <% if logged_in? && current_user == record.user %> <!-- ユーザーが投稿の所有者の場合にのみ表示 -->
         <%= link_to '編集', edit_record_path(record), class: 'btn btn-info btn-outline btn-sm' %>
         <%= link_to '削除', record_path(record), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-error btn-outline btn-sm' %>
+      <% end %>
 
-        <%= link_to "https://twitter.com/share?url=#{request.original_url}&text=#{CGI.escape(tweet_text(record))}", target: '_blank', rel: 'noopener noreferrer', class: 'btn btn-outline btn-sm' do %>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 inline-block fill-current hover:text-white">
-            <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
-          </svg>でシェア
-        <% end %>
-      </div>
-    <% end %>
+      <%= link_to "https://twitter.com/share?url=#{request.original_url}&text=#{CGI.escape(tweet_text(record))}", target: '_blank', rel: 'noopener noreferrer', class: 'btn btn-outline btn-sm' do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 inline-block fill-current hover:text-white">
+          <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+        </svg>でシェア
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_record_card.html.erb
+++ b/app/views/shared/_record_card.html.erb
@@ -1,0 +1,16 @@
+<div class="card bg-fuchsia-50 w-full border mx-auto my-5">
+  <div class="card-body">
+    <h2 class="card-title"><%= record.title %></h2>
+
+    <p><%= record.memo %></p>
+
+    <p><%= record.date.strftime('%Y-%m-%d') %></p>
+
+    <% if logged_in? && current_user == record.user %> <!-- ユーザーが投稿の所有者の場合にのみ表示 -->
+      <div class="card-actions justify-end">
+        <%= link_to '編集', edit_record_path(record), class: 'btn btn-info btn-outline btn-sm' %>
+        <%= link_to '削除', record_path(record), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-error btn-outline btn-sm' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_record_card.html.erb
+++ b/app/views/shared/_record_card.html.erb
@@ -14,7 +14,11 @@
         <%= link_to '編集', edit_record_path(record), class: 'btn btn-info btn-outline btn-sm' %>
         <%= link_to '削除', record_path(record), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-error btn-outline btn-sm' %>
 
-        <%= link_to 'Xでシェア', "https://twitter.com/share?url=#{request.original_url}&text=#{CGI.escape(tweet_text(record))}", target: '_blank', rel: 'noopener noreferrer', class: 'btn btn-outline btn-sm' %>
+        <%= link_to "https://twitter.com/share?url=#{request.original_url}&text=#{CGI.escape(tweet_text(record))}", target: '_blank', rel: 'noopener noreferrer', class: 'btn btn-outline btn-sm' do %>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 inline-block fill-current hover:text-white">
+            <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+          </svg>でシェア
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/_record_card.html.erb
+++ b/app/views/shared/_record_card.html.erb
@@ -1,6 +1,9 @@
-<div class="card bg-fuchsia-50 w-full border mx-auto my-5">
+<div class="card bg-fuchsia-50 text-primary-content w-full border mx-auto my-5">
   <div class="card-body">
-    <h2 class="card-title"><%= record.title %></h2>
+    <h2 class="card-title">
+      <div class="text-sm text-slate-500">生まれてはじめて</div>
+      <div class=""><%= record.title %></div>
+    </h2>
 
     <p><%= record.memo %></p>
 
@@ -10,6 +13,8 @@
       <div class="card-actions justify-end">
         <%= link_to '編集', edit_record_path(record), class: 'btn btn-info btn-outline btn-sm' %>
         <%= link_to '削除', record_path(record), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-error btn-outline btn-sm' %>
+
+        <%= link_to 'Xでシェア', "https://twitter.com/share?url=#{request.original_url}&text=#{CGI.escape(tweet_text(record))}", target: '_blank', rel: 'noopener noreferrer', class: 'btn btn-outline btn-sm' %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
### 概要

- ユーザーが「はじめての体験」をX（旧: Twitter）で簡単に共有できるよう、シェア機能を追加しました。
- 投稿表示部分をパーシャル化し、`records#index` と `public_records#index` で再利用できるようにしました。

### 変更内容

**1. Xシェア機能の追加**
  - 各投稿にXでのシェアボタンを追加。シェアされる内容は投稿タイトルと「#ForTheFirstTime」ハッシュタグを含みます。
  - シェアボタンをクリックすると、新しいタブでXの投稿画面が開きます。
  - 投稿のタイトルと「#ForTheFirstTime」ハッシュタグが含まれます。

**2. 投稿表示部分のパーシャル化**
  - `app/views/records/index.html.erb` と `app/views/public_records/index.html.erb` の投稿表示部分を `app/views/shared/_record_card.html.erb` にまとめました。
  - パーシャルにはシェアボタン、編集ボタン、削除ボタンを含み、ユーザーが投稿の所有者の場合に編集・削除ボタンが表示されます。
  - シェアボタンは、どのユーザーでも操作可能です。

**3. `application_helper.rb`にヘルパーメソッド追加**
  - Xシェアの投稿文を生成する `tweet_text` メソッドを追加し、シェアボタンに利用しています。

### 変更ファイル一覧

- `app/views/records/index.html.erb`
- `app/views/public_records/index.html.erb`
- `app/views/shared/_record_card.html.erb`
- `app/helpers/application_helper.rb`

## 動作確認

- ログインしたユーザーの投稿には編集・削除ボタンが表示され、Xシェアボタンが機能することを確認済みです。
- ログインしていないユーザーや他ユーザーの投稿では、編集・削除ボタンが表示されないことを確認済みです。

## 関連するIssue

- Issue #10 
