### PR TITLE
【fix】いいねボタンとモーダルのログイン状況に応じた表示の修正

### DIFF
--- a/app/views/likes/_disabled_button.html.erb
+++ b/app/views/likes/_disabled_button.html.erb
@@ -1,0 +1,5 @@
+<button class="mx-1 text-pink-500" disabled>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+  </svg>
+</button>

--- a/app/views/likes/_like_buttons.html.erb
+++ b/app/views/likes/_like_buttons.html.erb
@@ -1,5 +1,9 @@
-<% if current_user.likes.exists?(record: record) %>
-  <%= render 'likes/liked_button', record: record %>
+<% if logged_in? %>
+  <% if current_user.likes.exists?(record: record) %>
+    <%= render 'likes/liked_button', record: record %>
+  <% else %>
+    <%= render 'likes/unliked_button', record: record %>
+  <% end %>
 <% else %>
-  <%= render 'likes/unliked_button', record: record %>
+  <%= render 'likes/disabled_button', record: record %>
 <% end %>

--- a/app/views/likes/_like_count.html.erb
+++ b/app/views/likes/_like_count.html.erb
@@ -1,21 +1,28 @@
 <!-- いいね数を表示し、クリックでモーダルを開く -->
 <div class="like-count">
-  <button class="text-pink-500" onclick="like_modal_<%= record.id %>.showModal()">
-    <%= record.likes_count %>
-  </button>
+  <% if logged_in? %>
+    <button class="text-pink-500" onclick="like_modal_<%= record.id %>.showModal()">
+      <%= record.likes_count %>
+    </button>
+  <% else %>
+    <span class="text-pink-500">
+      <%= record.likes_count %>
+    </span>
+  <% end %>
 </div>
 
-<!-- モーダルの構造 -->
-<dialog id="like_modal_<%= record.id %>" class="modal">
-  <div class="modal-box">
-    <h3 class="text-lg font-bold">いいねしたユーザー</h3>
-    <ul>
-      <% record.likes.includes(:user).each do |like| %>
-        <li class="py-2"><%= like.user.name %></li>
-      <% end %>
-    </ul>
-  </div>
-  <form method="dialog" class="modal-backdrop"> <!-- 背景をクリックで閉じる -->
-    <button>close</button>
-  </form>
-</dialog>
+<% if logged_in? %>
+  <dialog id="like_modal_<%= record.id %>" class="modal">
+    <div class="modal-box">
+      <h3 class="text-lg font-bold">いいねしたユーザー</h3>
+      <ul>
+        <% record.likes.includes(:user).each do |like| %>
+          <li class="py-2"><%= like.user.name %></li>
+        <% end %>
+      </ul>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
+<% end %>


### PR DESCRIPTION
### 概要

ログイン状況に応じて、いいねボタンおよびいいね数の表示と挙動を調整しました。
未ログイン時は、いいねボタンを無効にし、いいね数はモーダルを表示せず、単なる数字表示とするように変更しました。

### 変更内容

1. **いいねボタンの変更**
   - ログインしていない場合にいいねボタンが無効化された状態で表示されるようにしました。
   - `_like_buttons.html.erb` において、ログインしていない場合は新規作成した `_disabled_button.html.erb` が表示されるように条件分岐を追加しました。

2. **いいね数表示の変更**
   - ログインしている場合にのみ、いいね数がモーダル表示されるようにしました。
   - `_like_count.html.erb` に条件分岐を追加し、ログインしていない場合はいいね数を数字表示のみに変更しました。

### 変更したファイル

- `app/views/likes/_like_buttons.html.erb`
- `app/views/likes/_like_count.html.erb`
- `app/views/likes/_disabled_button.html.erb`（新規追加）

### 動作確認
- ログイン時は通常通り、いいねの追加・削除が可能で、いいね数をクリックするとモーダルが表示されることを確認しました。
- ログアウト時は無効化されたいいねボタンが表示され、いいね数はクリックしてもモーダルが開かないことを確認しました。
